### PR TITLE
package: add version field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cluster-dashboard",
+  "version": "1.0.0",
   "description": "cockpit cluster dashboard",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Yocto's "devtool add" feature used to create a recipe requires a version number in the package.json to recognize that it's a project using npm and create the recipe based on this information.