### PR TITLE
nodeStatus: add new type of node

### DIFF
--- a/src/components/nodeStatus.jsx
+++ b/src/components/nodeStatus.jsx
@@ -12,16 +12,36 @@ export default class NodeStatus extends React.Component {
         this.state = {
             onlineNodes: [],
             offlineNodes: [],
+            remoteOnlineNodes: [],
+            remoteOfflineNodes: [],
+            guestOnlineNodes: [],
+            guestOfflineNodes: [],
             otherStatusNodes: [],
         };
 
         cockpit.spawn(["crm", "status", "--exclude=all", "--include=nodes"], {superuser: "try"})
             .then(output => {
-                const onlineNodes = extractOnlineNodes(output);
-                const offlineNodes = extractOfflineNodes(output);
+                const onlineNodes = extractNodesStatus(output,"Online");
+                const offlineNodes = extractNodesStatus(output, "OFFLINE");
+
+                const remoteOnlineNodes = extractNodesStatus(output,"RemoteOnline");
+                const remoteOfflineNodes = extractNodesStatus(output,"RemoteOFFLINE");
+
+
+                const guestOnlineNodes = extractNodesStatus(output,"GuestOnline");
+                const guestOfflineNodes = extractNodesStatus(output,"GuestOFFLINE");
+
                 const otherStatusNodes = extractOtherStatus(output);
 
-                this.setState({ onlineNodes, offlineNodes, otherStatusNodes });
+                this.setState({
+                    onlineNodes,
+                    offlineNodes,
+                    otherStatusNodes,
+                    remoteOnlineNodes,
+                    remoteOfflineNodes,
+                    guestOnlineNodes,
+                    guestOfflineNodes
+                 });
             });
     }
 
@@ -34,6 +54,28 @@ export default class NodeStatus extends React.Component {
                 <p id="node-status-offline-nodes" className="text">
                     { cockpit.format(("offline nodes : $0"), this.state.offlineNodes.join(' ')) }
                 </p>
+
+                {this.state.guestOnlineNodes.length > 0 && (
+                    <p className="text">
+                        {cockpit.format(("guest online nodes : $0"), this.state.guestOnlineNodes.join(' '))}
+                    </p>
+                )}
+                {this.state.guestOfflineNodes.length > 0 && (
+                    <p className="text">
+                        {cockpit.format(("guest offline nodes : $0"), this.state.guestOfflineNodes.join(' '))}
+                    </p>
+                )}
+                {this.state.remoteOnlineNodes.length > 0 && (
+                    <p className="text">
+                        {cockpit.format(("remote online nodes : $0"), this.state.remoteOnlineNodes.join(' '))}
+                    </p>
+                )}
+                {this.state.remoteOfflineNodes.length > 0 && (
+                    <p className="text">
+                        {cockpit.format(("remote offline nodes : $0"), this.state.remoteOfflineNodes.join(' '))}
+                    </p>
+                )}
+
                 <p id="other-node-status" className="text">
                     {this.state.otherStatusNodes.map((node, index) => (
                         <span key={index}>{node}<br/></span>
@@ -45,22 +87,16 @@ export default class NodeStatus extends React.Component {
     }
 }
 
-const extractOnlineNodes = (output) => {
-    // Catch the list of online nodes inside "Online: [<nodes>]"
-    const onlineNodesRegex = /\* Online: \[\s*([\w\s]+?)\s*\]/;
-    const onlineMatch = onlineNodesRegex.exec(output);
+const extractNodesStatus = (output, status) => {
+    // Get the list of nodes for a given status
+    // Ex with status = "Online":
+    // Online: [ adv-1 nuc1 observer ] -> adv-1 nuc1 observer
+    const statusNodesRegex = new RegExp(`${status}:\\s+\\[\\s*([^\\]]+)\\s*\\]`);
+    const nodesMatch = statusNodesRegex.exec(output);
     // If there is a match with the regex and the online node list is not empty, we collect them in an array
-    const onlineNodes = onlineMatch && onlineMatch[1] ? onlineMatch[1].split(' ') : [];
+    const nodeList = nodesMatch && nodesMatch[1] ? nodesMatch[1].split(' ') : [];
 
-    return onlineNodes;
-};
-
-const extractOfflineNodes = (output) => {
-    const offlineNodesRegex = /\* OFFLINE: \[\s*([\w\s]+?)\s*\]/;
-    const offlineMatch = offlineNodesRegex.exec(output);
-    const offlineNodes = offlineMatch && offlineMatch[1] ? offlineMatch[1].split(' ') : [];
-
-    return offlineNodes;
+    return nodeList;
 };
 
 // The nodes can also be in maintenance or standby mode


### PR DESCRIPTION
The regex has been modified to take the type of status (Ex: guestOFFILINE) exepected as an argument. This allows to get the status of remote and guest nodes.